### PR TITLE
bug-fix/ Cant set headers after they are sent to client

### DIFF
--- a/controllers/auth/emailVerification.js
+++ b/controllers/auth/emailVerification.js
@@ -76,7 +76,7 @@ export const verifyEmailLink = async (req, res) => {
       return res.status(400).send({ msg: 'Invalid link' });
     } else {
       const userToken = newToken(user);
-      return res.status(200).json({
+      return res.status(200).send({
         msg: `Hi, ${user.firstName}! Your email has been successfully verified. Please Sign In to finish setting up your account.`,
         user: user,
         bootcamprNewToken: userToken,
@@ -84,7 +84,7 @@ export const verifyEmailLink = async (req, res) => {
     }
   } catch (error) {
     console.log(error.message);
-    return res.status(500).json({ status: false, message: error.message });
+    res.status(500).json({ status: false, message: error.message });
   }
 };
 
@@ -147,7 +147,7 @@ export const verifyUniqueEmail = async (req, res) => {
     } else if (user) {
       throw new Error('Email address already exists.');
     } else {
-      return res.status(200).json({ message: 'Email is valid and unique.' });
+      res.status(200).json({ message: 'Email is valid and unique.' });
     }
   } catch (error) {
     let statusCode = 400;
@@ -157,7 +157,7 @@ export const verifyUniqueEmail = async (req, res) => {
     } else if (error.message === 'Email already exists.') {
       statusCode = 409;
     }
-    return res.status(statusCode).send({ error: error.message });
+    res.status(statusCode).send({ error: error.message });
   }
 };
 

--- a/controllers/auth/emailVerification.js
+++ b/controllers/auth/emailVerification.js
@@ -75,8 +75,9 @@ export const verifyEmailLink = async (req, res) => {
     if (!user) {
       return res.status(400).send({ msg: 'Invalid link' });
     }
+
     const userToken = newToken(user);
-    return res.status(200).send({
+    res.status(200).send({
       msg: `Hi, ${user.firstName}! Your email has been successfully verified. Please Sign In to finish setting up your account.`,
       user: user,
       bootcamprNewToken: userToken,

--- a/controllers/auth/emailVerification.js
+++ b/controllers/auth/emailVerification.js
@@ -74,14 +74,13 @@ export const verifyEmailLink = async (req, res) => {
     const user = await User.findByIdAndUpdate({ _id: req.params.id }, { verified: true }, { new: true });
     if (!user) {
       return res.status(400).send({ msg: 'Invalid link' });
-    } else {
-      const userToken = newToken(user);
-      return res.status(200).send({
-        msg: `Hi, ${user.firstName}! Your email has been successfully verified. Please Sign In to finish setting up your account.`,
-        user: user,
-        bootcamprNewToken: userToken,
-      });
     }
+    const userToken = newToken(user);
+    return res.status(200).send({
+      msg: `Hi, ${user.firstName}! Your email has been successfully verified. Please Sign In to finish setting up your account.`,
+      user: user,
+      bootcamprNewToken: userToken,
+    });
   } catch (error) {
     console.log(error.message);
     res.status(500).json({ status: false, message: error.message });


### PR DESCRIPTION
The Sign Up Email Verification flow was crashing our backend server due to a "Can't set headers after they are sent to the client" error.

Some researching suggested we may be trying to send multiple responses for a single request.

I located this bug in our code where the `verifyValidToken` helper function was attempting to prematurely send a 401 response to the client, rather than deferring the response management to its parent function (`verifyEmailLink`).

This PR addresses this bug by trimming the response management out of the helper function and leaving it to the parent function.

I tested locally with and without these changes and was able to confirm that without them I received `Can't set headers after they are sent to client` and once the changes were implemented, I no longer receive this error, and am able to successfullly:
* click verification link in my email
* backend verifies email with no errors
* get redirected to my profile screen