### PR TITLE
Refactor/bc 647 group chat routes

### DIFF
--- a/controllers/auth/auth.js
+++ b/controllers/auth/auth.js
@@ -303,6 +303,20 @@ export const updateEmail = async (req, res) => {
   }
 };
 
+export const getUserIdFromToken = (authHeader) => {
+  if (!authHeader || authHeader.split(' ')[0] !== 'Bearer') {
+    throw new Error('No or invalid token provided');
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const decodedToken = jwt.verify(token, TOKEN_KEY);
+    const userId = decodedToken.userID;
+    return userId;
+  } catch (error) {
+    throw new Error('Invalid token');
+  }
+};
+
 // Potentinal new User Controllers
 //
 // Assign Project - User

--- a/controllers/chat/media.js
+++ b/controllers/chat/media.js
@@ -5,7 +5,9 @@ import GroupChat from '../../models/chat/groupChat.js';
 
 export const createMediaMessage = async (req, res) => {
   try {
-    const { userId, privateChatId, groupChatId } = req.params;
+    const authHeader = req.headers.authorization;
+    const userId = getUserIdFromToken(authHeader);
+    const { privateChatId, groupChatId } = req.params;
     const { fileName, fileType, fileSize, fileUrl } = req.body;
     let existingThread;
 
@@ -52,7 +54,7 @@ export const getAllMedia = async (req, res) => {
   }
 };
 
-export const getMediaByChatId = async (req, res) => {
+export const getMediaMessage = async (req, res) => {
   try {
     const { privateChatId, groupChatId } = req.params;
     if (privateChatId) {
@@ -111,7 +113,7 @@ export const getMediaByUserId = async (req, res) => {
 export const getChatMediaByFileType = async (req, res) => {
   try {
     const { privateChatId, groupChatId } = req.params;
-    const { fileType } = req.query;
+    const fileType = req.query.type;
 
     if (privateChatId) {
       const mediaMessages = await Media.find({ privateChatId });

--- a/routes/chat/groupChat.js
+++ b/routes/chat/groupChat.js
@@ -2,34 +2,37 @@ import { Router } from 'express';
 import {
   createGroupChatMessage,
   createGroupChatRoom,
-  deleteGChat,
+  deleteGroupChat,
   deleteGroupChatThread,
   deleteMessage,
-  getAllGroupChatsByUserId,
-  getAllGroupMessages,
+  getUserGroupChats,
+  getGroupChatMessages,
   getAllUsersGroupChats,
   getGroupChatByChatId,
   leaveGroupChat,
   updateGroupChatInfo,
 } from '../../controllers/chat/groupChat.js';
-import { createMediaMessage, getChatMediaByFileType, getMediaByChatId } from '../../controllers/chat/media.js';
+import { createMediaMessage, getChatMediaByFileType, getMediaMessage } from '../../controllers/chat/media.js';
 const router = Router();
 
 router.get('/groupChats', getAllUsersGroupChats);
-router.post('/:userId/groupChats', createGroupChatRoom);
-router.post('/:userId/groupChats/:groupChatId', createGroupChatMessage);
-router.get('/:userId/groupChats', getAllGroupChatsByUserId);
-router.get('/:userId/groupChats/:groupChatId', getAllGroupMessages);
 router.get('/groupChats/:groupChatId', getGroupChatByChatId);
-router.put('/:userId/groupChats/:groupChatId', updateGroupChatInfo);
-router.delete('/:userId/groupChats/:groupChatId', deleteGroupChatThread);
-router.put('/:userId/:groupChatId', leaveGroupChat);
-router.delete('/groupChats/:chatId', deleteGChat);
+router.get('/groupChats/:groupChatId/messages', getGroupChatMessages);
+router.delete('/groupChats/:groupChatId', deleteGroupChat);
 router.delete('/groupChats/:groupChatId/messages', deleteMessage);
+//user's group chats
+//ASK - instead of getting user id from endpoint we can get it from token to avoid  /users/userId/chats/id etc.. but not sure which is better
+router.get('/user/groupChats', getUserGroupChats);
+router.post('/user/groupChats', createGroupChatRoom);
+router.post('/user/groupChats/:groupChatId/messages', createGroupChatMessage);
+router.put('/user/groupChats/:groupChatId', updateGroupChatInfo);
+//ASK - not sure about this endpoint, we're extracting userId from headers, also should we use delete instead of put?
+router.put('/groupChats/:groupChatId/participants/me', leaveGroupChat);
+router.delete('/user/groupChats/:groupChatId', deleteGroupChatThread);
 
 // Media Messages
-router.post('/:userId/groupChats/:groupChatId/media', createMediaMessage);
-router.get('/groupChats/:groupChatId/media', getMediaByChatId);
-router.get('/groupChats/:groupChatId/media/:fileType', getChatMediaByFileType);
+router.get('/groupChats/:groupChatId/media', getMediaMessage);
+router.get('/groupChats/:groupChatId/media?type=fileType', getChatMediaByFileType);
+router.post('/user/groupChats/:groupChatId/media', createMediaMessage);
 
 export default router;

--- a/routes/chat/privateChat.js
+++ b/routes/chat/privateChat.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createMediaMessage, getChatMediaByFileType, getMediaByChatId } from '../../controllers/chat/media.js';
+import { createMediaMessage, getChatMediaByFileType, getMediaMessage } from '../../controllers/chat/media.js';
 import {
   createPrivateChatMessage,
   createPrivateChatRoom,
@@ -17,7 +17,7 @@ router.delete('/:userId/privateChats/:privateChatId', deleteMessageThread);
 
 // Media Messages
 router.post('/:userId/privateChats/:privateChatId/media', createMediaMessage);
-router.get('/privateChats/:privateChatId/media', getMediaByChatId);
+router.get('/privateChats/:privateChatId/media', getMediaMessage);
 router.get('/privateChats/:privateChatId/media/:fileType', getChatMediaByFileType);
 
 export default router;


### PR DESCRIPTION
- Group chats and user group chats are separated 
- `/:userId` is removed from the beginning of the endpoints
- updated group chat controllers

[BC-647](https://bootcamper.atlassian.net/browse/BC-647)

[BC-647]: https://bootcamper.atlassian.net/browse/BC-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ