### PR TITLE
Feature/Add version service route

### DIFF
--- a/.github/workflows/version-bump.js.yml
+++ b/.github/workflows/version-bump.js.yml
@@ -1,0 +1,29 @@
+name: "Bump Version"
+
+on:
+  pull_request:
+
+jobs:
+  bump-version:
+    name: "Bump Version on development branch"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout soruce code"
+        uses: "actions/checkout@v2"
+        with:
+          ref: ${{ github.ref }}
+      - name: "cat package.json"
+        run: cat ./package.json
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@v1"
+        with:
+          node-version: 18
+      - name: "Automated Version Bump"
+        uses: "phips28/gh-action-bump-version@master"
+        with:
+          tag-prefix: ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "cat package.json"
+        run: cat ./package.json

--- a/controllers/service.js
+++ b/controllers/service.js
@@ -1,0 +1,14 @@
+export const getApiVersion = async (req, res) => {
+    try {
+        const currentVersion = process.env.npm_package_version
+
+        res.status(200).json({
+            version: currentVersion
+        });
+    } catch (error) {
+        res.status(500).json({
+            message: 'Unable to get service version.',
+            error: error.message,
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootcamper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bootcamper",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.216.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootcamper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,6 +12,8 @@ import chatThreadRoutes from './chat/thread.js';
 import projectRoutes from './project/projects.js';
 import ticketRoutes from './project/tickets.js';
 import userRoutes from './user/users.js';
+import serviceRoutes from './service.js';
+
 const router = Router();
 
 //BC-647: these routes need to be updated with more semantic routes
@@ -30,5 +32,6 @@ router.use('/', chatThreadRoutes);
 router.use('/', projectRoutes);
 router.use('/', ticketRoutes);
 router.use('/', userRoutes);
+router.use('/', serviceRoutes);
 
 export default router;

--- a/routes/service.js
+++ b/routes/service.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getApiVersion } from '../controllers/service.js';
+
+const router = Router();
+
+router.get('/service/version', getApiVersion);
+
+export default router;


### PR DESCRIPTION
This PR allows us to check the current version of our deployed server on any environment by hitting:
`GET .../service/version` 
The response will look like:
```
{
     "version": "1.2.13"
}
```

This PR also sets up a Github Action that will automatically bump the package.json version on a merge to development so we can start implementing versioning of our API (This action still needs a bit of testing, and is currently configured to run on pull_requests but once confirmed the action works, I'll update to run on merge to development)